### PR TITLE
Untyped mirror instead of cache, support for adding refs in Deltas

### DIFF
--- a/js/src/main/scala/org/rebeam/tree/view/Cursor.scala
+++ b/js/src/main/scala/org/rebeam/tree/view/Cursor.scala
@@ -8,7 +8,7 @@ import japgolly.scalajs.react.extra.Reusability
 import org.rebeam.tree.ref.{Mirror, MirrorCodec, Ref}
 
 trait Root {
-  def cursorAt[A, L](ref: Ref[A], location: L): Option[Cursor[A, L]]
+  def cursorAt[A, L](ref: Ref[A], location: L)(implicit mca: MirrorCodec[A]): Option[Cursor[A, L]]
 }
 
 /**
@@ -83,7 +83,7 @@ trait Cursor[M, L] extends Parent[M] {
 
   def move[N](newLocation: N): Cursor[M, N] = CursorBasic(parent, model, newLocation, root)
 
-  def followRef[A](ref: Ref[A]): Option[Cursor[A, L]] = root.cursorAt(ref, location)
+  def followRef[A](ref: Ref[A])(implicit mca: MirrorCodec[A]): Option[Cursor[A, L]] = root.cursorAt(ref, location)
 
 }
 
@@ -92,7 +92,7 @@ private case class CursorBasic[M, L](parent: Parent[M], model: M, location: L, r
 object Cursor {
 
   object RootNone extends Root {
-    override def cursorAt[A, L](ref: Ref[A], location: L): Option[Cursor[A, L]] = None
+    override def cursorAt[A, L](ref: Ref[A], location: L)(implicit mca: MirrorCodec[A]): Option[Cursor[A, L]] = None
   }
 
   def apply[M, L](parent: Parent[M], model: M, location: L, root: Root): Cursor[M, L] = CursorBasic(parent, model, location, root)

--- a/js/src/main/scala/org/rebeam/tree/view/Cursor.scala
+++ b/js/src/main/scala/org/rebeam/tree/view/Cursor.scala
@@ -4,14 +4,20 @@ import japgolly.scalajs.react._
 import org.rebeam.tree._
 import org.rebeam.lenses._
 import io.circe._
-import org.rebeam.tree.ref.Cache
-import org.rebeam.tree.ref.Ref
+import japgolly.scalajs.react.extra.Reusability
+import org.rebeam.tree.ref.{Mirror, MirrorCodec, Ref}
+
+trait Root {
+  def cursorAt[A, L](ref: Ref[A], location: L): Option[Cursor[A, L]]
+}
 
 /**
   * Cursor giving a "position" in a data model, providing the value at that position
   * and a parent to be used to run deltas as a callback to update the entire model,
   * as well as means to zoom into the model (using lenses and similar) to produce
   * cursors for child data.
+  *
+  * Also provides a Mirror for resolving refs
   *
   * Most commonly used by a view of a position in a model, since it provides the
   * data to display, and a way of applying deltas to the data at that position.
@@ -41,6 +47,12 @@ trait Cursor[M, L] extends Parent[M] {
     */
   def location: L
 
+  /**
+    * Source for producing new cursors from a ref and location
+    * @return cursor source
+    */
+  def root: Root
+
   //Just pass through callback to parent for convenience
   def callback(delta: Delta[M], deltaJs: Json): Callback = parent.callback(delta, deltaJs)
 
@@ -61,29 +73,36 @@ trait Cursor[M, L] extends Parent[M] {
 //  def zoom[C] = new Zoomer[C]()
 
   def zoom[C](lens: LensN[M, C]): Cursor[C, L] =
-    CursorBasic[C, L](LensNParent(parent, lens), lens.get(model), location)
+    CursorBasic[C, L](LensNParent(parent, lens), lens.get(model), location, root)
 
   def zoomPrism[C](prismN: PrismN[M, C]): Option[Cursor[C, L]] = {
-    prismN.getOption(model).map(c => CursorBasic[C, L](PrismNParent[M, C](parent, prismN), c, location))
+    prismN.getOption(model).map(c => CursorBasic[C, L](PrismNParent[M, C](parent, prismN), c, location, root))
   }
 
-  def label(label: String): Cursor[M, String] = CursorBasic(parent, model, label)
+  def label(label: String): Cursor[M, String] = CursorBasic(parent, model, label, root)
 
-  def move[N](newLocation: N): Cursor[M, N] = CursorBasic(parent, model, newLocation)
+  def move[N](newLocation: N): Cursor[M, N] = CursorBasic(parent, model, newLocation, root)
+
+  def followRef[A](ref: Ref[A]): Option[Cursor[A, L]] = root.cursorAt(ref, location)
+
 }
 
-private case class CursorBasic[M, L](parent: Parent[M], model: M, location: L) extends Cursor[M, L]
+private case class CursorBasic[M, L](parent: Parent[M], model: M, location: L, root: Root) extends Cursor[M, L]
 
 object Cursor {
 
-  def apply[M, L](parent: Parent[M], model: M, location: L): Cursor[M, L] = CursorBasic(parent, model, location)
+  object RootNone extends Root {
+    override def cursorAt[A, L](ref: Ref[A], location: L): Option[Cursor[A, L]] = None
+  }
+
+  def apply[M, L](parent: Parent[M], model: M, location: L, root: Root): Cursor[M, L] = CursorBasic(parent, model, location, root)
 
   implicit class ListCursor[C, L](cursor: Cursor[List[C], L]) {
 
     def zoomI(index: Int): Option[Cursor[C, L]] = {
       val optionalI: OptionalI[C] = OptionalI[C](index)
       optionalI.getOption(cursor.model).map { c =>
-        Cursor[C, L](OptionalIParent(cursor.parent, optionalI), c, cursor.location)
+        Cursor[C, L](OptionalIParent(cursor.parent, optionalI), c, cursor.location, cursor.root)
       }
     }
 
@@ -94,7 +113,7 @@ object Cursor {
     def zoomMatch[F <: C => Boolean](f: F)(implicit fEncoder: Encoder[F]): Option[Cursor[C, L]] = {
       val optionalMatch: OptionalMatch[C, F] = OptionalMatch[C, F](f)
       optionalMatch.getOption(cursor.model).map { c =>
-        Cursor[C, L](OptionalMatchParent(cursor.parent, optionalMatch), c, cursor.location)
+        Cursor[C, L](OptionalMatchParent(cursor.parent, optionalMatch), c, cursor.location, cursor.root)
       }
     }
 
@@ -105,20 +124,25 @@ object Cursor {
   implicit class OptionCursor[C, L](cursor: Cursor[Option[C], L]) {
     def zoomOption: Option[Cursor[C, L]] = {
       cursor.model.map { c =>
-        Cursor[C, L](OptionParent[C](cursor.parent), c, cursor.location)
+        Cursor[C, L](OptionParent[C](cursor.parent), c, cursor.location, cursor.root)
       }
     }
   }
 
-  implicit class CacheCursor[A, L](cursor: Cursor[Cache[A], L]) {
-    def zoomRef(ref: Ref[A]): Option[Cursor[A, L]] = {
+  implicit class MirrorCursor[L](cursor: Cursor[Mirror, L]) {
+    def zoomRef[A: MirrorCodec](ref: Ref[A]): Option[Cursor[A, L]] = {
       cursor.model(ref).map { data =>
-        Cursor[A, L](CacheParent[A](cursor.parent, OptionalCache(ref)), data, cursor.location)
+        Cursor[A, L](MirrorParent[A](cursor.parent, ref), data, cursor.location, cursor.root)
       }
     }
-
-    def zoomRefPrism[B <: A](ref: Ref[B])(implicit p: PrismN[A, B]): Option[Cursor[B, L]] = {
-      zoomRef(ref).flatMap(c => c.zoomPrism[B](p))
-    }
   }
+
+  /**
+    * Compare cursors based on parent, model and location, ignoring root
+    * @tparam M   Model type
+    * @tparam L   Location type
+    * @return     Reusability for cursor
+    */
+  implicit def cursorReusability[M, L]: Reusability[Cursor[M, L]] = Reusability.fn{case (c1, c2) => c1.parent == c2.parent && c1.model == c2.model && c1.location == c2.location}
+
 }

--- a/js/src/main/scala/org/rebeam/tree/view/ServerRootComponent.scala
+++ b/js/src/main/scala/org/rebeam/tree/view/ServerRootComponent.scala
@@ -11,15 +11,37 @@ import scala.util.{Failure, Success}
 import io.circe._
 import io.circe.parser._
 import io.circe.syntax._
-
+import org.rebeam.tree.ref.{Mirror, MirrorCodec}
 object ServerRootComponent {
+
+  trait RootSource[R] {
+    def rootFor(rootModel: R, parent: Parent[R]): Root
+  }
+
+  private class MirrorRootSource extends RootSource[Mirror] {
+    def rootFor(rootModel: Mirror, parent: Parent[Mirror]): Root = new Root {
+      def cursorAt[A, L](ref: org.rebeam.tree.ref.Ref[A], location: L)(implicit mca: MirrorCodec[A]): Option[Cursor[A, L]] = {
+        rootModel.apply(ref).map { data =>
+          Cursor[A, L](MirrorParent[A](parent, ref), data, location, this)
+        }
+      }
+    }
+  }
+
+  implicit val mirrorRootSource: RootSource[Mirror] = new MirrorRootSource
+
+  private class NoRootSource[R] extends RootSource[R] {
+    def rootFor(rootModel: R, parent: Parent[R]): Root = Cursor.RootNone
+  }
+
+  def noRootSource[R]: RootSource[R] = new NoRootSource[R]
 
   case class Props[R, P](p: P, render: Cursor[R, P] => ReactElement, wsUrl: String, noData: ReactElement)
 
   case class State[R](clientState: Option[ClientState[R]], ws: Option[WebSocket], tick: Option[SetIntervalHandle])
 
   class Backend[R, P](scope: BackendScope[Props[R, P], State[R]])
-    (implicit decoder: Decoder[R], deltaDecoder: Decoder[Delta[R]], idGen: ModelIdGen[R], contextSource: DeltaIOContextSource) {
+    (implicit decoder: Decoder[R], deltaDecoder: Decoder[Delta[R]], idGen: ModelIdGen[R], contextSource: DeltaIOContextSource, rootSource: RootSource[R]) {
 
     implicit val cme = clientMsgEncoder[R]
 
@@ -52,7 +74,7 @@ object ServerRootComponent {
     def render(props: Props[R, P], state: State[R]) = {
       state.clientState.map { cs =>
         //FIXME actual root!
-        val cursorP = Cursor(rootParent, cs.model, props.p, Cursor.RootNone)
+        val cursorP = Cursor(rootParent, cs.model, props.p, rootSource.rootFor(cs.model, rootParent))
         props.render(cursorP)
       }.getOrElse(
         props.noData
@@ -153,8 +175,8 @@ object ServerRootComponent {
   def factory[R, P]
     (noData: ReactElement, wsUrl: String)
     (render: Cursor[R, P] => ReactElement)
-    (implicit decoder: Decoder[R], deltaDecoder: Decoder[Delta[R]], idGen: ModelIdGen[R], contextSource: DeltaIOContextSource) = {
-    val c = ctor[R, P](decoder, deltaDecoder, idGen, contextSource)
+    (implicit decoder: Decoder[R], deltaDecoder: Decoder[Delta[R]], idGen: ModelIdGen[R], contextSource: DeltaIOContextSource, rootSource: RootSource[R]) = {
+    val c = ctor[R, P](decoder, deltaDecoder, idGen, contextSource, rootSource)
     (page: P) => c(Props[R, P](page, render, wsUrl, noData))
   }
 
@@ -162,15 +184,15 @@ object ServerRootComponent {
   def apply[R]
   (noData: ReactElement, wsUrl: String)
   (render: Cursor[R, Unit] => ReactElement)
-  (implicit decoder: Decoder[R], deltaDecoder: Decoder[Delta[R]], idGen: ModelIdGen[R], contextSource: DeltaIOContextSource) = {
-    val c = ctor[R, Unit](decoder, deltaDecoder, idGen, contextSource)
+  (implicit decoder: Decoder[R], deltaDecoder: Decoder[Delta[R]], idGen: ModelIdGen[R], contextSource: DeltaIOContextSource, rootSource: RootSource[R]) = {
+    val c = ctor[R, Unit](decoder, deltaDecoder, idGen, contextSource, rootSource)
     c(Props[R, Unit]((), render, wsUrl, noData))
   }
 
   //Just make the component constructor - props to be supplied later to make a component
-  def ctor[R, P](implicit decoder: Decoder[R], deltaDecoder: Decoder[Delta[R]], idGen: ModelIdGen[R], contextSource: DeltaIOContextSource) = ReactComponentB[Props[R, P]]("ServerRootComponent")
+  def ctor[R, P](implicit decoder: Decoder[R], deltaDecoder: Decoder[Delta[R]], idGen: ModelIdGen[R], contextSource: DeltaIOContextSource, rootSource: RootSource[R]) = ReactComponentB[Props[R, P]]("ServerRootComponent")
     .initialState(State[R](None, None, None))
-    .backend(new Backend[R, P](_)(decoder, deltaDecoder, idGen, contextSource))
+    .backend(new Backend[R, P](_)(decoder, deltaDecoder, idGen, contextSource, rootSource))
     .render(s => s.backend.render(s.props, s.state))
     .componentDidMount(_.backend.start)
     .componentWillUnmount(_.backend.end)

--- a/js/src/main/scala/org/rebeam/tree/view/ServerRootComponent.scala
+++ b/js/src/main/scala/org/rebeam/tree/view/ServerRootComponent.scala
@@ -51,7 +51,8 @@ object ServerRootComponent {
 
     def render(props: Props[R, P], state: State[R]) = {
       state.clientState.map { cs =>
-        val cursorP = Cursor(rootParent, cs.model, props.p)
+        //FIXME actual root!
+        val cursorP = Cursor(rootParent, cs.model, props.p, Cursor.RootNone)
         props.render(cursorP)
       }.getOrElse(
         props.noData

--- a/js/src/main/scala/org/rebeam/tree/view/ServerRootComponent.scala
+++ b/js/src/main/scala/org/rebeam/tree/view/ServerRootComponent.scala
@@ -2,7 +2,7 @@ package org.rebeam.tree.view
 
 import japgolly.scalajs.react._
 import org.rebeam.tree._
-import org.rebeam.tree.sync.ClientState
+import org.rebeam.tree.sync.{ClientState, RefAdder}
 import org.rebeam.tree.sync.Sync._
 import org.scalajs.dom._
 
@@ -41,7 +41,7 @@ object ServerRootComponent {
   case class State[R](clientState: Option[ClientState[R]], ws: Option[WebSocket], tick: Option[SetIntervalHandle])
 
   class Backend[R, P](scope: BackendScope[Props[R, P], State[R]])
-    (implicit decoder: Decoder[R], deltaDecoder: Decoder[Delta[R]], idGen: ModelIdGen[R], contextSource: DeltaIOContextSource, rootSource: RootSource[R]) {
+    (implicit decoder: Decoder[R], deltaDecoder: Decoder[Delta[R]], idGen: ModelIdGen[R], contextSource: DeltaIOContextSource, rootSource: RootSource[R], refAdder: RefAdder[R]) {
 
     implicit val cme = clientMsgEncoder[R]
 
@@ -52,7 +52,7 @@ object ServerRootComponent {
           _ <- s.clientState match {
             case None =>
               // TODO implement
-              println("Delta before we have a clientState! Should queue deltas?")
+              Callback{println("Delta before we have a clientState! Should queue deltas?")}
             case Some(cs) => {
               //SIDE-EFFECT: Note this is the point at which we generate the context
               val (newCS, id) = cs.apply(delta, contextSource.getContext)
@@ -175,8 +175,8 @@ object ServerRootComponent {
   def factory[R, P]
     (noData: ReactElement, wsUrl: String)
     (render: Cursor[R, P] => ReactElement)
-    (implicit decoder: Decoder[R], deltaDecoder: Decoder[Delta[R]], idGen: ModelIdGen[R], contextSource: DeltaIOContextSource, rootSource: RootSource[R]) = {
-    val c = ctor[R, P](decoder, deltaDecoder, idGen, contextSource, rootSource)
+    (implicit decoder: Decoder[R], deltaDecoder: Decoder[Delta[R]], idGen: ModelIdGen[R], contextSource: DeltaIOContextSource, rootSource: RootSource[R], refAdder: RefAdder[R]) = {
+    val c = ctor[R, P](decoder, deltaDecoder, idGen, contextSource, rootSource, refAdder)
     (page: P) => c(Props[R, P](page, render, wsUrl, noData))
   }
 
@@ -184,15 +184,15 @@ object ServerRootComponent {
   def apply[R]
   (noData: ReactElement, wsUrl: String)
   (render: Cursor[R, Unit] => ReactElement)
-  (implicit decoder: Decoder[R], deltaDecoder: Decoder[Delta[R]], idGen: ModelIdGen[R], contextSource: DeltaIOContextSource, rootSource: RootSource[R]) = {
-    val c = ctor[R, Unit](decoder, deltaDecoder, idGen, contextSource, rootSource)
+  (implicit decoder: Decoder[R], deltaDecoder: Decoder[Delta[R]], idGen: ModelIdGen[R], contextSource: DeltaIOContextSource, rootSource: RootSource[R], refAdder: RefAdder[R]) = {
+    val c = ctor[R, Unit](decoder, deltaDecoder, idGen, contextSource, rootSource, refAdder)
     c(Props[R, Unit]((), render, wsUrl, noData))
   }
 
   //Just make the component constructor - props to be supplied later to make a component
-  def ctor[R, P](implicit decoder: Decoder[R], deltaDecoder: Decoder[Delta[R]], idGen: ModelIdGen[R], contextSource: DeltaIOContextSource, rootSource: RootSource[R]) = ReactComponentB[Props[R, P]]("ServerRootComponent")
+  def ctor[R, P](implicit decoder: Decoder[R], deltaDecoder: Decoder[Delta[R]], idGen: ModelIdGen[R], contextSource: DeltaIOContextSource, rootSource: RootSource[R], refAdder: RefAdder[R]) = ReactComponentB[Props[R, P]]("ServerRootComponent")
     .initialState(State[R](None, None, None))
-    .backend(new Backend[R, P](_)(decoder, deltaDecoder, idGen, contextSource, rootSource))
+    .backend(new Backend[R, P](_)(decoder, deltaDecoder, idGen, contextSource, rootSource, refAdder))
     .render(s => s.backend.render(s.props, s.state))
     .componentDidMount(_.backend.start)
     .componentWillUnmount(_.backend.end)

--- a/js/src/main/scala/org/rebeam/tree/view/ServerRootComponent.scala
+++ b/js/src/main/scala/org/rebeam/tree/view/ServerRootComponent.scala
@@ -52,7 +52,7 @@ object ServerRootComponent {
           _ <- s.clientState match {
             case None =>
               // TODO implement
-              Callback{"Delta before we have a clientState! Should queue deltas?"}
+              println("Delta before we have a clientState! Should queue deltas?")
             case Some(cs) => {
               //SIDE-EFFECT: Note this is the point at which we generate the context
               val (newCS, id) = cs.apply(delta, contextSource.getContext)

--- a/shared/src/main/scala/org/rebeam/tree/DeltaCodecs.scala
+++ b/shared/src/main/scala/org/rebeam/tree/DeltaCodecs.scala
@@ -204,7 +204,7 @@ object DeltaCodecs {
       val o = c.downField("mirror").downField(mirrorCodecA.mirrorType.name)
       for {
         ref <- o.downField("ref").as[Ref[A]]
-        delta <- o.downField("delta").as[Delta[A]]
+        delta <- mirrorCodecA.deltaCodec.tryDecode(o.downField("delta"))
       } yield MirrorDelta[A](ref, delta)
     })
 

--- a/shared/src/main/scala/org/rebeam/tree/OptionalCache.scala
+++ b/shared/src/main/scala/org/rebeam/tree/OptionalCache.scala
@@ -1,27 +1,27 @@
-package org.rebeam.tree
-
-import monocle.{Optional, POptional}
-import org.rebeam.tree.ref.Cache
-import org.rebeam.tree.ref.Ref
-
-import scalaz.{Applicative, \/}
-
-import scala.language.higherKinds
-
-case class OptionalCache[A](ref: Ref[A]) extends POptional[Cache[A], Cache[A], A, A] {
-  lazy val o: Optional[Cache[A], A] = Optional[Cache[A], A](
-    c => c(ref)
-  )(
-    a => c => c.updated(ref.guid, a)
-  )
-
-  def getOrModify(s: Cache[A]): Cache[A] \/ A = o.getOrModify(s)
-
-  def set(a: A): Cache[A] => Cache[A] = o.set(a)
-
-  def getOption(s: Cache[A]): Option[A] = o.getOption(s)
-
-  def modifyF[F[_]: Applicative](f: A => F[A])(s: Cache[A]): F[Cache[A]] = o.modifyF(f)(s)
-
-  def modify(f: A => A): Cache[A] => Cache[A] = o.modify(f)
-}
+//package org.rebeam.tree
+//
+//import monocle.{Optional, POptional}
+//import org.rebeam.tree.ref.Mirror
+//import org.rebeam.tree.ref.Ref
+//
+//import scalaz.{Applicative, \/}
+//
+//import scala.language.higherKinds
+//
+//case class OptionalMirror[A](ref: Ref[A]) extends POptional[Mirror, Mirror, A, A] {
+//  lazy val o: Optional[Mirror, A] = Optional[Mirror, A](
+//    c => c(ref)
+//  )(
+//    a => c => c.updated(ref.guid, a)
+//  )
+//
+//  def getOrModify(s: Mirror): Mirror \/ A = o.getOrModify(s)
+//
+//  def set(a: A): Mirror => Mirror = o.set(a)
+//
+//  def getOption(s: Mirror): Option[A] = o.getOption(s)
+//
+//  def modifyF[F[_]: Applicative](f: A => F[A])(s: Mirror): F[Mirror] = o.modifyF(f)(s)
+//
+//  def modify(f: A => A): Mirror => Mirror = o.modify(f)
+//}

--- a/shared/src/main/scala/org/rebeam/tree/ref/Cache.scala
+++ b/shared/src/main/scala/org/rebeam/tree/ref/Cache.scala
@@ -1,229 +1,226 @@
-package org.rebeam.tree.ref
-
-import io.circe._
-import monocle.PPrism
-import org.rebeam.tree.DeltaCodecs.{DeltaCodec, RefUpdateResult}
-import org.rebeam.tree.sync.Sync.{Guid, ToId}
-import org.rebeam.tree.ref.Ref._
-
-trait RefUpdater {
-  /**
-    * Update a ref to the latest version if necessary
-    * @param ref  The ref to update
-    * @tparam A   The type of the referent
-    * @return     Some(updated ref) if update is needed, None otherwise
-    */
-  def updateRef[A](ref: Ref[A]): Option[Ref[A]]
-}
-
-object Cache {
-  def empty[M: DeltaCodec] = new Cache[M](Map.empty)
-
-  implicit val guidKeyEncoder: KeyEncoder[Guid[_]] = new KeyEncoder[Guid[_]] {
-    override def apply(key: Guid[_]): String = Guid.toString(key)
-  }
-
-  implicit val guidKeyDecoder = new KeyDecoder[Guid[_]] {
-    override def apply(key: String): Option[Guid[_]] = Guid.fromString(key)
-  }
-
-  // Decode as a plain map from guid to data, then add the entries to an actual Cache to update refs etc.
-  implicit def decodeCache[M](implicit dm: Decoder[M], deltaCodec: DeltaCodec[M]): Decoder[Cache[M]] =
-    Decoder.decodeMapLike[Map, Guid[_], M].map(
-      // Fold over entries in map, accumulating them into a cache
-      _.foldLeft(Cache.empty[M]){
-        // Here we have to assume that the cache was valid when encoded, so that in each entry
-        // the Guid was for the correct type of data, and also matches any Guid used in the
-        // future to look up data in the cache.
-        case (cache, entry) => cache.updated(entry._1.asInstanceOf[Guid[M]], entry._2)
-      }
-    )
-
-  // Encode by converting to a plain map from guid to data, and encoding the guids as their string representation
-  // so we can use a normal map Json encoding
-  implicit def encodeCache[M](implicit em: Encoder[M]): Encoder[Cache[M]] =
-    Encoder.encodeMapLike[Map, Guid[_], M](guidKeyEncoder, em).contramap[Cache[M]](_.map.mapValues(_.data))
-
-}
-
-private case class CacheState[A](data: A, revision: Long, incomingRefs: Set[Guid[_]], outgoingRefs: Set[Guid[_]]) {
-  def updatedIncomingRefs(id: Guid[_], add: Boolean): CacheState[A] = copy(
-    incomingRefs = if (add) {
-      incomingRefs + id
-    } else {
-      incomingRefs - id
-    }
-  )
-}
-
-class Cache[M](private val map: Map[Guid[_], CacheState[M]])(implicit dCodecM: DeltaCodec[M]) extends RefUpdater {
-
-  /**
-    * Retrieve the data for a reference, if reference is valid and data is present in cache
-    * @param ref  The reference
-    * @return     The data if present, or None otherwise
-    */
-  def apply(ref: Ref[M]): Option[M] = getState(ref.guid).map(_.data)
-//    ref match {
-//    case RefUnresolved(_) => None
-//    case RefResolved(guid, revision) => getState(guid).filter(_.revision == revision).map(_.data)
+//package org.rebeam.tree.ref
+//
+//import io.circe._
+//import monocle.PPrism
+//import org.rebeam.tree.DeltaCodecs.{DeltaCodec, RefUpdateResult}
+//import org.rebeam.tree.sync.Sync.{Guid, ToId}
+//import org.rebeam.tree.ref.Ref._
+//
+//trait RefUpdater {
+//  /**
+//    * Update a ref to the latest version if necessary
+//    * @param ref  The ref to update
+//    * @tparam A   The type of the referent
+//    * @return     Some(updated ref) if update is needed, None otherwise
+//    */
+//  def updateRef[A](ref: Ref[A]): Option[Ref[A]]
+//}
+//
+//object Cache {
+//  def empty[M: DeltaCodec] = new Cache[M](Map.empty)
+//
+//  implicit val guidKeyEncoder: KeyEncoder[Guid[_]] = new KeyEncoder[Guid[_]] {
+//    override def apply(key: Guid[_]): String = Guid.toString(key)
 //  }
-
-  /**
-    * Retrieve the data for a reference, and then convert to another type via a PPrism
-    * @param ref  The reference
-    * @param p    The prism to use for conversion
-    * @tparam A   The type to which prism converts (from M)
-    * @return     The data if present in cache and convertible by p.getOption, or None otherwise
-    */
-  def prism[A <: M](ref: Ref[A])(implicit p: PPrism[M, _, A, _]): Option[A] = apply(ref).flatMap(p.getOption _)
-
-  def updateRef[A](ref: Ref[A]): Option[Ref[A]] = getState(ref.guid).fold[Option[Ref[A]]]{
-    // If ref is not in cache, update to unresolved
-    Some(RefUnresolved(ref.guid))
-  }{
-    // If ref is in cache, update to resolved at current revision
-    state => Some(RefResolved(ref.guid, state.revision))
-  // Skip update if new ref is equal to old one
-  }.filterNot(_ == ref)
-
-  def incomingRefs(id: Guid[M]): Set[Guid[_]] = getState(id).map(_.incomingRefs).getOrElse(Set.empty[Guid[_]])
-  def outgoingRefs(id: Guid[M]): Set[Guid[_]] = getState(id).map(_.outgoingRefs).getOrElse(Set.empty[Guid[_]])
-
-  def get(id: Guid[M]): Option[M] = getState(id).map(_.data)
-
-  def getPrism[A <: M](id: Guid[A])(implicit p: PPrism[M, _, A, _]): Option[A] = get(id).flatMap(p.getOption _)
-
-  private def getState(id: Guid[_]): Option[CacheState[M]] = map.get(id)
-
-  private def incomingRefsFor(id: Guid[_]): Set[Guid[_]] = {
-    map.foldLeft(Set.empty[Guid[_]]){
-      case (refs, entry) =>
-        // If the entry represents data having an outgoing ref to our id, then
-        // add that data's id to the incoming refs.
-        // Ignore the outgoing refs of our own data
-        if (entry._2.outgoingRefs.contains(id) && entry._1 != id) {
-          refs + entry._1
-          // No outgoing ref from the entry's data to our id, so leave refs unaltered
-        } else {
-          refs
-        }
-    }
-  }
-
-  private def updateIncomingRefs(id: Guid[_], outgoingRefs: Set[Guid[_]], add: Boolean): Cache[M] = {
-    val map2 = outgoingRefs.foldLeft(map){
-      case (m, outgoingRef) =>
-        m.get(outgoingRef).fold {
-          // If data reached by outgoing ref is not in cache, nothing to update
-          m
-        }{
-          // If data IS in the cache, we update its cache state to add/remove ourselves as an incoming ref
-          (otherCacheState: CacheState[M]) =>
-            m.updated(
-              outgoingRef,
-              otherCacheState.updatedIncomingRefs(id, add)
-            )
-        }
-    }
-    new Cache[M](map2)
-  }
-
-  def updated(a: M)(implicit toId: ToId[M]): Cache[M] = updated(toId.id(a), a)
-
-  def updated(id: Guid[M], a: M): Cache[M] = {
-    val state = getState(id)
-
-    // Next revision, or start from 0
-    val updatedRev = state.map(_.revision + 1).getOrElse(0L)
-
-    // Update refs in the updated data
-    val updateResult = dCodecM.updateRefs(RefUpdateResult.noRefs(a), this)
-
-    // If data was already in cache, incoming refs do not change just because data
-    // is updated. Otherwise build incoming refs from scratch
-    val incomingRefs = state.map(_.incomingRefs).getOrElse(incomingRefsFor(id))
-
-    // Updated map for this data item, using the results of update, and updated rev
-    val map2 = map.updated(id, CacheState(updateResult.data, updatedRev, incomingRefs, updateResult.outgoingRefs))
-
-    // If data was already in cache, look up previous outgoing refs - otherwise treat as empty
-    val previousOutgoingRefs = state.map(_.outgoingRefs).getOrElse(Set.empty)
-    val currentOutgoingRefs = updateResult.outgoingRefs
-
-    // Updated cache with the updated map, plus updated incoming refs.
-    val cache2 = new Cache[M](map2)
-
-    // We look at our previous and current outgoing refs - where we have
-    // a new outgoing ref we need to add ourselves to the incoming refs of the
-    // newly-referenced data. Similarly where we have lost an outgoing ref we will
-    // remove ourselves from the incoming refs of the previously-referenced data.
-    val cache3 = cache2
-      .updateIncomingRefs(id, currentOutgoingRefs -- previousOutgoingRefs, add = true)
-      .updateIncomingRefs(id, previousOutgoingRefs -- currentOutgoingRefs, add = false)
-
-    // Finally, we need to update the refs in everything that points at us to get our new revision.
-    // This doesn't trigger any further updates, since the actual data in those
-    // data items that point at us hasn't changed.
-    incomingRefs.foldLeft(cache3){
-      case (c, incomingId) =>
-        c.getState(incomingId).fold(
-          // If the data that refers to us is not in the cache, no update
-          // This should not happen, since we only get an incoming reference when the data
-          // is added to the cache, and when it is removed the incoming reference is cleared.
-          // However dangling incoming references do no harm other than triggering these
-          // no-ops.
-          c
-        )(
-          // If data is in cache, update its references to get our new revision
-          state => {
-            val rur = dCodecM.updateRefs(RefUpdateResult.noRefs(state.data.asInstanceOf[M]), c)
-            new Cache[M](c.map.updated(incomingId, state.copy(data = rur.data)))
-          }
-        )
-    }
-  }
-
-  /**
-    * Create a new Cache with a data item not present (same cache if data was
-    * not in the cache)
-    * @param id Id of data to remove
-    * @return   New cache with data item not present
-    */
-  def removed(id: Guid[M]): Cache[M] = {
-    getState(id).fold{
-      this
-    }{
-      state =>
-        // First remove the data item from map
-        // Then update the incoming refs of everything the data item referred to, to
-        // remove the data item.
-        val cache2 = new Cache[M](map - id).updateIncomingRefs(id, state.outgoingRefs, add = false)
-
-        // Finally, we need to update the refs in everything that points at the removed data so that they will have
-        // RefUnresolved, since data is no longer in the cache.
-        // This doesn't trigger any further updates, since the actual data in those
-        // data items that point at the removed data hasn't changed.
-        state.incomingRefs.foldLeft(cache2){
-          case (c, incomingId) =>
-            c.getState(incomingId).fold(
-              // If the data that refers to removed data is not in the cache, no update
-              // This should not happen, since we only get an incoming reference when the data
-              // is added to the cache, and when it is removed the incoming reference is cleared.
-              // However dangling incoming references do no harm other than triggering these
-              // no-ops.
-              c
-            )(
-              // If data is in cache, update its references to get an unresolved ref for the removed data
-              state => {
-                val rur = dCodecM.updateRefs(RefUpdateResult.noRefs(state.data.asInstanceOf[M]), c)
-                new Cache[M](c.map.updated(incomingId, state.copy(data = rur.data)))
-              }
-            )
-        }
-
-    }
-  }
-
-    override def toString: String = "Cache(" + map + ")"
-}
+//
+//  implicit val guidKeyDecoder = new KeyDecoder[Guid[_]] {
+//    override def apply(key: String): Option[Guid[_]] = Guid.fromString(key)
+//  }
+//
+//  // Decode as a plain map from guid to data, then add the entries to an actual Cache to update refs etc.
+//  implicit def decodeCache[M](implicit dm: Decoder[M], deltaCodec: DeltaCodec[M]): Decoder[Cache[M]] =
+//    Decoder.decodeMapLike[Map, Guid[_], M].map(
+//      // Fold over entries in map, accumulating them into a cache
+//      _.foldLeft(Cache.empty[M]){
+//        // Here we have to assume that the cache was valid when encoded, so that in each entry
+//        // the Guid was for the correct type of data, and also matches any Guid used in the
+//        // future to look up data in the cache.
+//        case (cache, entry) => cache.updated(entry._1.asInstanceOf[Guid[M]], entry._2, entry._1.asInstanceOf[Guid[M]])
+//      }
+//    )
+//
+//  // Encode by converting to a plain map from guid to data, and encoding the guids as their string representation
+//  // so we can use a normal map Json encoding
+//  implicit def encodeCache[M](implicit em: Encoder[M]): Encoder[Cache[M]] =
+//    Encoder.encodeMapLike[Map, Guid[_], M](guidKeyEncoder, em).contramap[Cache[M]](_.map.mapValues(_.data))
+//
+//}
+//
+//private case class CacheState[A](data: A, revision: Guid[A], incomingRefs: Set[Guid[_]], outgoingRefs: Set[Guid[_]]) {
+//  def updatedIncomingRefs(id: Guid[_], add: Boolean): CacheState[A] = copy(
+//    incomingRefs = if (add) {
+//      incomingRefs + id
+//    } else {
+//      incomingRefs - id
+//    }
+//  )
+//}
+//
+//class Cache[M](private val map: Map[Guid[_], CacheState[M]])(implicit dCodecM: DeltaCodec[M]) extends RefUpdater {
+//
+//  /**
+//    * Retrieve the data for a reference, if reference is valid and data is present in cache
+//    * @param ref  The reference
+//    * @return     The data if present, or None otherwise
+//    */
+//  def apply(ref: Ref[M]): Option[M] = getState(ref.guid).map(_.data)
+////    ref match {
+////    case RefUnresolved(_) => None
+////    case RefResolved(guid, revision) => getState(guid).filter(_.revision == revision).map(_.data)
+////  }
+//
+//  /**
+//    * Retrieve the data for a reference, and then convert to another type via a PPrism
+//    * @param ref  The reference
+//    * @param p    The prism to use for conversion
+//    * @tparam A   The type to which prism converts (from M)
+//    * @return     The data if present in cache and convertible by p.getOption, or None otherwise
+//    */
+//  def prism[A <: M](ref: Ref[A])(implicit p: PPrism[M, _, A, _]): Option[A] = apply(ref).flatMap(p.getOption _)
+//
+//  def updateRef[A](ref: Ref[A]): Option[Ref[A]] = getState(ref.guid).fold[Option[Ref[A]]]{
+//    // If ref is not in cache, update to unresolved
+//    Some(RefUnresolved(ref.guid))
+//  }{
+//    // If ref is in cache, update to resolved at current revision
+//    state => Some(RefResolved[A](ref.guid, state.revision.asInstanceOf[Guid[A]]))
+//  // Skip update if new ref is equal to old one
+//  }.filterNot(_ == ref)
+//
+//  def incomingRefs(id: Guid[M]): Set[Guid[_]] = getState(id).map(_.incomingRefs).getOrElse(Set.empty[Guid[_]])
+//  def outgoingRefs(id: Guid[M]): Set[Guid[_]] = getState(id).map(_.outgoingRefs).getOrElse(Set.empty[Guid[_]])
+//
+//  def get(id: Guid[M]): Option[M] = getState(id).map(_.data)
+//
+//  def getPrism[A <: M](id: Guid[A])(implicit p: PPrism[M, _, A, _]): Option[A] = get(id).flatMap(p.getOption _)
+//
+//  private def getState(id: Guid[_]): Option[CacheState[M]] = map.get(id)
+//
+//  private def incomingRefsFor(id: Guid[_]): Set[Guid[_]] = {
+//    map.foldLeft(Set.empty[Guid[_]]){
+//      case (refs, entry) =>
+//        // If the entry represents data having an outgoing ref to our id, then
+//        // add that data's id to the incoming refs.
+//        // Ignore the outgoing refs of our own data
+//        if (entry._2.outgoingRefs.contains(id) && entry._1 != id) {
+//          refs + entry._1
+//          // No outgoing ref from the entry's data to our id, so leave refs unaltered
+//        } else {
+//          refs
+//        }
+//    }
+//  }
+//
+//  private def updateIncomingRefs(id: Guid[_], outgoingRefs: Set[Guid[_]], add: Boolean): Cache[M] = {
+//    val map2 = outgoingRefs.foldLeft(map){
+//      case (m, outgoingRef) =>
+//        m.get(outgoingRef).fold {
+//          // If data reached by outgoing ref is not in cache, nothing to update
+//          m
+//        }{
+//          // If data IS in the cache, we update its cache state to add/remove ourselves as an incoming ref
+//          (otherCacheState: CacheState[M]) =>
+//            m.updated(
+//              outgoingRef,
+//              otherCacheState.updatedIncomingRefs(id, add)
+//            )
+//        }
+//    }
+//    new Cache[M](map2)
+//  }
+//
+//  def updated(a: M, updatedRev: Guid[M])(implicit toId: ToId[M]): Cache[M] = updated(toId.id(a), a, updatedRev)
+//
+//  def updated(id: Guid[M], a: M, updatedRev: Guid[M]): Cache[M] = {
+//    val state = getState(id)
+//
+//    // Update refs in the updated data
+//    val updateResult = dCodecM.updateRefs(RefUpdateResult.noRefs(a), this)
+//
+//    // If data was already in cache, incoming refs do not change just because data
+//    // is updated. Otherwise build incoming refs from scratch
+//    val incomingRefs = state.map(_.incomingRefs).getOrElse(incomingRefsFor(id))
+//
+//    // Updated map for this data item, using the results of update, and updated rev
+//    val map2 = map.updated(id, CacheState(updateResult.data, updatedRev, incomingRefs, updateResult.outgoingRefs))
+//
+//    // If data was already in cache, look up previous outgoing refs - otherwise treat as empty
+//    val previousOutgoingRefs = state.map(_.outgoingRefs).getOrElse(Set.empty)
+//    val currentOutgoingRefs = updateResult.outgoingRefs
+//
+//    // Updated cache with the updated map, plus updated incoming refs.
+//    val cache2 = new Cache[M](map2)
+//
+//    // We look at our previous and current outgoing refs - where we have
+//    // a new outgoing ref we need to add ourselves to the incoming refs of the
+//    // newly-referenced data. Similarly where we have lost an outgoing ref we will
+//    // remove ourselves from the incoming refs of the previously-referenced data.
+//    val cache3 = cache2
+//      .updateIncomingRefs(id, currentOutgoingRefs -- previousOutgoingRefs, add = true)
+//      .updateIncomingRefs(id, previousOutgoingRefs -- currentOutgoingRefs, add = false)
+//
+//    // Finally, we need to update the refs in everything that points at us to get our new revision.
+//    // This doesn't trigger any further updates, since the actual data in those
+//    // data items that point at us hasn't changed.
+//    incomingRefs.foldLeft(cache3){
+//      case (c, incomingId) =>
+//        c.getState(incomingId).fold(
+//          // If the data that refers to us is not in the cache, no update
+//          // This should not happen, since we only get an incoming reference when the data
+//          // is added to the cache, and when it is removed the incoming reference is cleared.
+//          // However dangling incoming references do no harm other than triggering these
+//          // no-ops.
+//          c
+//        )(
+//          // If data is in cache, update its references to get our new revision
+//          state => {
+//            val rur = dCodecM.updateRefs(RefUpdateResult.noRefs(state.data), c)
+//            new Cache[M](c.map.updated(incomingId, state.copy(data = rur.data)))
+//          }
+//        )
+//    }
+//  }
+//
+//  /**
+//    * Create a new Cache with a data item not present (same cache if data was
+//    * not in the cache)
+//    * @param id Id of data to remove
+//    * @return   New cache with data item not present
+//    */
+//  def removed(id: Guid[M]): Cache[M] = {
+//    getState(id).fold{
+//      this
+//    }{
+//      state =>
+//        // First remove the data item from map
+//        // Then update the incoming refs of everything the data item referred to, to
+//        // remove the data item.
+//        val cache2 = new Cache[M](map - id).updateIncomingRefs(id, state.outgoingRefs, add = false)
+//
+//        // Finally, we need to update the refs in everything that points at the removed data so that they will have
+//        // RefUnresolved, since data is no longer in the cache.
+//        // This doesn't trigger any further updates, since the actual data in those
+//        // data items that point at the removed data hasn't changed.
+//        state.incomingRefs.foldLeft(cache2){
+//          case (c, incomingId) =>
+//            c.getState(incomingId).fold(
+//              // If the data that refers to removed data is not in the cache, no update
+//              // This should not happen, since we only get an incoming reference when the data
+//              // is added to the cache, and when it is removed the incoming reference is cleared.
+//              // However dangling incoming references do no harm other than triggering these
+//              // no-ops.
+//              c
+//            )(
+//              // If data is in cache, update its references to get an unresolved ref for the removed data
+//              state => {
+//                val rur = dCodecM.updateRefs(RefUpdateResult.noRefs(state.data.asInstanceOf[M]), c)
+//                new Cache[M](c.map.updated(incomingId, state.copy(data = rur.data)))
+//              }
+//            )
+//        }
+//
+//    }
+//  }
+//
+//    override def toString: String = "Cache(" + map + ")"
+//}

--- a/shared/src/main/scala/org/rebeam/tree/ref/Mirror.scala
+++ b/shared/src/main/scala/org/rebeam/tree/ref/Mirror.scala
@@ -1,0 +1,253 @@
+package org.rebeam.tree.ref
+
+import io.circe._
+import org.rebeam.tree.DeltaCodecs.{DeltaCodec, RefUpdateResult}
+import org.rebeam.tree.sync.Sync.{Guid, ToId}
+import org.rebeam.tree.ref.Ref._
+
+//trait RefUpdater {
+//  /**
+//    * Update a ref to the latest version if necessary
+//    * @param ref  The ref to update
+//    * @tparam A   The type of the referent
+//    * @return     Some(updated ref) if update is needed, None otherwise
+//    */
+//  def updateRef[A](ref: Ref[A]): Option[Ref[A]]
+//}
+
+/**
+  * Represents a type of data referenced in a Mirror
+  * @param name   The name of the type, must only be associated with one real type in a given mirror.
+  */
+case class MirrorType(name: String) extends AnyVal
+
+/**
+  * Typeclass covering everything needed to contain a type of data in a Mirror
+  * @tparam A     The type of data
+  */
+trait MirrorCodec[A] extends DeltaCodec[A] {
+  def decoderA: Decoder[A]
+  def encoderA: Encoder[A]
+  def mirrorType: MirrorType
+}
+
+object Mirror {
+  val empty = new Mirror(Map.empty, Map.empty)
+
+  implicit val guidKeyEncoder: KeyEncoder[Guid[_]] = new KeyEncoder[Guid[_]] {
+    override def apply(key: Guid[_]): String = Guid.toString(key)
+  }
+
+  implicit val guidKeyDecoder = new KeyDecoder[Guid[_]] {
+    override def apply(key: String): Option[Guid[_]] = Guid.fromString(key)
+  }
+
+//  // Decode as a plain map from guid to data, then add the entries to an actual Mirror to update refs etc.
+//  def mirrorDecoder(implicit dm: Decoder[M], deltaCodec: DeltaCodec[M]): Decoder[Mirror[M]] =
+//    Decoder.decodeMapLike[Map, Guid[_], M].map(
+//      // Fold over entries in map, accumulating them into a cache
+//      _.foldLeft(Mirror.empty[M]){
+//        // Here we have to assume that the cache was valid when encoded, so that in each entry
+//        // the Guid was for the correct type of data, and also matches any Guid used in the
+//        // future to look up data in the cache.
+//        case (cache, entry) => cache.updated(entry._1.asInstanceOf[Guid[M]], entry._2)
+//      }
+//    )
+
+  // Encode by converting to a plain map from guid to data, and encoding the guids as their string representation
+  // so we can use a normal map Json encoding
+//  def mirrorEncoder(): Encoder[Mirror[M]] =
+//    Encoder.encodeMapLike[Map, Guid[_], M](guidKeyEncoder, em).contramap[Mirror[M]](_.map.mapValues(_.data))
+
+}
+
+/**
+  * The state of a piece of data in the Mirror
+  * @param data           The data itself
+  * @param revision       The current revision of the data
+  * @param incomingRefs   The Guids of all other pieces of data in the Mirror that contain references to this data
+  * @param outgoingRefs   The Guids of all other pieces of data in the Mirror that are referenced by this data
+  * @param mirrorCodec    A MirrorCodec for the data type
+  * @tparam A             The data type
+  */
+private case class MirrorState[A](data: A, revision: Long, incomingRefs: Set[Guid[_]], outgoingRefs: Set[Guid[_]], mirrorCodec: MirrorCodec[A]) {
+  def updatedIncomingRefs(id: Guid[_], add: Boolean): MirrorState[A] = copy(
+    incomingRefs = if (add) {
+      incomingRefs + id
+    } else {
+      incomingRefs - id
+    }
+  )
+}
+
+/**
+  * A Mirror handles the client side of synchronising a key value map between a client and server.
+  * @param map    Map from each known Guid to the data identified by that Guid
+  * @param types  Map from types of data in the mirror to the associated codecs
+  */
+class Mirror(private val map: Map[Guid[_], MirrorState[_]], private val types: Map[MirrorType, MirrorCodec[_]]) extends RefUpdater {
+
+  private def updateMap(newMap: Map[Guid[_], MirrorState[_]]): Mirror = new Mirror(newMap, types)
+
+  def updateType[A](mirrorType: MirrorType, mirrorCodec: MirrorCodec[A]) = new Mirror(map, types.updated(mirrorType, mirrorCodec))
+
+  /**
+    * Retrieve the data for a reference, if reference is valid and data is present in cache
+    * @param ref  The reference
+    * @return     The data if present, or None otherwise
+    */
+  def apply[A](ref: Ref[A]): Option[A] = getState(ref.guid).map(_.data)
+//    ref match {
+//    case RefUnresolved(_) => None
+//    case RefResolved(guid, revision) => getState(guid).filter(_.revision == revision).map(_.data)
+//  }
+
+  def updateRef[A](ref: Ref[A]): Option[Ref[A]] = getState(ref.guid).fold[Option[Ref[A]]]{
+    // If ref is not in cache, update to unresolved
+    Some(RefUnresolved(ref.guid))
+  }{
+    // If ref is in cache, update to resolved at current revision
+    state => Some(RefResolved(ref.guid, state.revision))
+  // Skip update if new ref is equal to old one
+  }.filterNot(_ == ref)
+
+  def incomingRefs(id: Guid[_]): Set[Guid[_]] = getState(id).map(_.incomingRefs).getOrElse(Set.empty[Guid[_]])
+  def outgoingRefs(id: Guid[_]): Set[Guid[_]] = getState(id).map(_.outgoingRefs).getOrElse(Set.empty[Guid[_]])
+
+  def get[A](id: Guid[A]): Option[A] = getState(id).map(_.data)
+
+  private def getState[A](id: Guid[A]): Option[MirrorState[A]] = map.get(id).map(_.asInstanceOf[MirrorState[A]])
+
+  private def incomingRefsFor(id: Guid[_]): Set[Guid[_]] = {
+    map.foldLeft(Set.empty[Guid[_]]){
+      case (refs, entry) =>
+        // If the entry represents data having an outgoing ref to our id, then
+        // add that data's id to the incoming refs.
+        // Ignore the outgoing refs of our own data
+        if (entry._2.outgoingRefs.contains(id) && entry._1 != id) {
+          refs + entry._1
+          // No outgoing ref from the entry's data to our id, so leave refs unaltered
+        } else {
+          refs
+        }
+    }
+  }
+
+  private def updateIncomingRefs(id: Guid[_], outgoingRefs: Set[Guid[_]], add: Boolean): Mirror = {
+    val map2 = outgoingRefs.foldLeft(map){
+      case (m, outgoingRef) =>
+        m.get(outgoingRef).fold {
+          // If data reached by outgoing ref is not in cache, nothing to update
+          m
+        }{
+          // If data IS in the cache, we update its cache state to add/remove ourselves as an incoming ref
+          (otherMirrorState: MirrorState[_]) =>
+            m.updated(
+              outgoingRef,
+              otherMirrorState.updatedIncomingRefs(id, add)
+            )
+        }
+    }
+    updateMap(map2)
+  }
+
+  def updated[A](a: A)(implicit toId: ToId[A], mCodecA: MirrorCodec[A]): Mirror = updated(toId.id(a), a)
+
+  def updated[A](id: Guid[A], a: A)(implicit mCodecA: MirrorCodec[A]): Mirror = {
+    val state = getState(id)
+
+    // Next revision, or start from 0
+    val updatedRev = state.map(_.revision + 1).getOrElse(0L)
+
+    // Update refs in the updated data
+    val updateResult = mCodecA.updateRefs(RefUpdateResult.noRefs(a), this)
+
+    // If data was already in cache, incoming refs do not change just because data
+    // is updated. Otherwise build incoming refs from scratch
+    val incomingRefs = state.map(_.incomingRefs).getOrElse(incomingRefsFor(id))
+
+    // Updated map for this data item, using the results of update, and updated rev
+    val map2 = map.updated(id, MirrorState(updateResult.data, updatedRev, incomingRefs, updateResult.outgoingRefs, mCodecA))
+
+    // If data was already in cache, look up previous outgoing refs - otherwise treat as empty
+    val previousOutgoingRefs = state.map(_.outgoingRefs).getOrElse(Set.empty)
+    val currentOutgoingRefs = updateResult.outgoingRefs
+
+    // Updated mirror with the updated map, plus updated incoming refs, and with the MirrorCodec added
+    // in case we don't have it already
+    val cache2 = new Mirror(map2, types.updated(mCodecA.mirrorType, mCodecA))
+
+    // We look at our previous and current outgoing refs - where we have
+    // a new outgoing ref we need to add ourselves to the incoming refs of the
+    // newly-referenced data. Similarly where we have lost an outgoing ref we will
+    // remove ourselves from the incoming refs of the previously-referenced data.
+    val cache3 = cache2
+      .updateIncomingRefs(id, currentOutgoingRefs -- previousOutgoingRefs, add = true)
+      .updateIncomingRefs(id, previousOutgoingRefs -- currentOutgoingRefs, add = false)
+
+    // Finally, we need to update the refs in everything that points at us to get our new revision.
+    // This doesn't trigger any further updates, since the actual data in those
+    // data items that point at us hasn't changed.
+    incomingRefs.foldLeft(cache3){
+      case (c, incomingId) =>
+        c.getState(incomingId).fold(
+          // If the data that refers to us is not in the cache, no update
+          // This should not happen, since we only get an incoming reference when the data
+          // is added to the cache, and when it is removed the incoming reference is cleared.
+          // However dangling incoming references do no harm other than triggering these
+          // no-ops.
+          c
+        )(
+          // If data is in cache, update its references to get our new revision
+          state => {
+            val rur = state.mirrorCodec.updateRefs(RefUpdateResult.noRefs(state.data), c)
+            c.updateMap(c.map.updated(incomingId, state.copy(data = rur.data)))
+          }
+        )
+    }
+  }
+
+  /**
+    * Create a new Mirror with a data item not present (same cache if data was
+    * not in the cache)
+    * @param id Id of data to remove
+    * @return   New cache with data item not present
+    */
+  def removed[A](id: Guid[A]): Mirror = {
+    getState(id).fold{
+      this
+    }{
+      state =>
+        // First remove the data item from map
+        // Then update the incoming refs of everything the data item referred to, to
+        // remove the data item.
+        val cache2 = updateMap(map - id).updateIncomingRefs(id, state.outgoingRefs, add = false)
+
+        // Finally, we need to update the refs in everything that points at the removed data so that they will have
+        // RefUnresolved, since data is no longer in the cache.
+        // This doesn't trigger any further updates, since the actual data in those
+        // data items that point at the removed data hasn't changed.
+        state.incomingRefs.foldLeft(cache2){
+          case (c, incomingId) =>
+            c.getState(incomingId).fold(
+              // If the data that refers to removed data is not in the cache, no update
+              // This should not happen, since we only get an incoming reference when the data
+              // is added to the cache, and when it is removed the incoming reference is cleared.
+              // However dangling incoming references do no harm other than triggering these
+              // no-ops.
+              c
+            )(
+              // If data is in cache, update its references to get an unresolved ref for the removed data
+              state => {
+                // FIXME get the codec from state
+                val rur = state.mirrorCodec.updateRefs(RefUpdateResult.noRefs(state.data), c)
+                c.updateMap(c.map.updated(incomingId, state.copy(data = rur.data)))
+              }
+            )
+        }
+
+    }
+  }
+
+    override def toString: String = "Mirror(" + map + ")"
+}

--- a/shared/src/main/scala/org/rebeam/tree/ref/Mirror.scala
+++ b/shared/src/main/scala/org/rebeam/tree/ref/Mirror.scala
@@ -180,6 +180,10 @@ class Mirror(private val map: Map[Guid[_], MirrorState[_]], private val types: M
 //    case RefResolved(guid, revision) => getState(guid).filter(_.revision == revision).map(_.data)
 //  }
 
+  def revisionOf[A](ref: Ref[A]): Option[Guid[A]] = getState(ref.guid).map(_.revision)
+
+  def revisionOf[A](guid: Guid[A]): Option[Guid[A]] = getState(guid).map(_.revision)
+
   def updateRef[A](ref: Ref[A]): Option[Ref[A]] = getState(ref.guid).fold[Option[Ref[A]]]{
     // If ref is not in mirror, update to unresolved
     Some(RefUnresolved(ref.guid))

--- a/shared/src/main/scala/org/rebeam/tree/ref/Mirror.scala
+++ b/shared/src/main/scala/org/rebeam/tree/ref/Mirror.scala
@@ -169,6 +169,9 @@ class Mirror(private val map: Map[Guid[_], MirrorState[_]], private val types: M
 
   def updateType[A](mirrorType: MirrorType, mirrorCodec: MirrorCodec[A]) = new Mirror(map, types.updated(mirrorType, mirrorCodec))
 
+  //FIXME using wrong revision should probably fail - this is going to be the best
+  //way to see that we have failed to update a ref in a model to match data revision,
+  //otherwise we will jsut get stale data in React...
   /**
     * Retrieve the data for a reference, if reference is valid and data is present in mirror
     * @param ref  The reference

--- a/shared/src/main/scala/org/rebeam/tree/sync/DeltaIORun.scala
+++ b/shared/src/main/scala/org/rebeam/tree/sync/DeltaIORun.scala
@@ -4,11 +4,16 @@ import cats.data.State
 import cats.~>
 import org.rebeam.tree.Delta._
 import org.rebeam.tree._
+import org.rebeam.tree.ref.MirrorCodec
 import org.rebeam.tree.sync.Sync._
 
 object DeltaIORun {
 
-  private case class StateData(context: DeltaIOContext, deltaId: DeltaId, currentGuidId: Long) {
+  case class AddedRef[A](id: Guid[A], data: A, revision: Guid[A], codec: MirrorCodec[A])
+
+  case class DeltaRunResult[A](data: A, addedRefs: List[AddedRef[_]])
+
+  private case class StateData(context: DeltaIOContext, deltaId: DeltaId, currentGuidId: Long, addedRefs: List[AddedRef[_]]) {
     def withNextGuidId: StateData = copy(currentGuidId = currentGuidId + 1)
   }
 
@@ -22,34 +27,48 @@ object DeltaIORun {
           case GetId() => State(s => (s.withNextGuidId, Guid[Any](s.deltaId.clientId, s.deltaId.clientDeltaId, s.currentGuidId)))
 
           case GetContext => State(s => (s, s.context))
+
+          case Put(create, codec) => State(s => {
+            val guid = Guid[A](s.deltaId.clientId, s.deltaId.clientDeltaId, s.currentGuidId)
+            val revision = Guid[A](s.deltaId.clientId, s.deltaId.clientDeltaId, s.currentGuidId + 1)
+            val createDIO: DeltaIO[A] = create(guid)
+            // Remember to increment guid twice for the guid and revision we generated
+            val stateWithA = createDIO.foldMap(pureCompiler).run(s.withNextGuidId.withNextGuidId).value
+
+            val newAddedRefs = AddedRef(guid, stateWithA._2, revision, codec) :: stateWithA._1.addedRefs
+            (stateWithA._1.copy(addedRefs = newAddedRefs), stateWithA._2)
+          })
         }
     }
 
-  def runDeltaIO[A](dc: DeltaIO[A], context: DeltaIOContext, deltaId: DeltaId): A =
-    dc.foldMap(pureCompiler).run(StateData(context, deltaId, 0)).value._2
+  def runDeltaIO[A](dc: DeltaIO[A], context: DeltaIOContext, deltaId: DeltaId): DeltaRunResult[A] = {
+    val s = dc.foldMap(pureCompiler).run(StateData(context, deltaId, 0, Nil)).value
+    DeltaRunResult(s._2, s._1.addedRefs)
+  }
+
 
   implicit class DeltaRun[A](d: Delta[A]) {
-    def runWith(a: A, context: DeltaIOContext, deltaId: DeltaId): A = runDeltaIO(d(a), context, deltaId)
+    def runWith(a: A, context: DeltaIOContext, deltaId: DeltaId): DeltaRunResult[A] = runDeltaIO(d(a), context, deltaId)
   }
 
   implicit class DeltaIORun[A](dio: DeltaIO[A]) {
-    def runWith(context: DeltaIOContext, deltaId: DeltaId): A = runDeltaIO(dio, context, deltaId)
+    def runWith(context: DeltaIOContext, deltaId: DeltaId): DeltaRunResult[A] = runDeltaIO(dio, context, deltaId)
   }
 
   implicit class DeltaAndIdRun[A](deltaAndId: DeltaAndId[A]) {
-    def runWith(a: A, context: DeltaIOContext): A = runDeltaIO(deltaAndId.delta.apply(a), context, deltaAndId.id)
+    def runWith(a: A, context: DeltaIOContext): DeltaRunResult[A] = runDeltaIO(deltaAndId.delta.apply(a), context, deltaAndId.id)
   }
 
   implicit class DeltaWithIJRun[A](dij: DeltaWithIJ[A]) {
-    def runWith(a: A, context: DeltaIOContext): A = runDeltaIO(dij.delta.apply(a), context, dij.id)
+    def runWith(a: A, context: DeltaIOContext): DeltaRunResult[A] = runDeltaIO(dij.delta.apply(a), context, dij.id)
   }
 
   implicit class DeltaWithIJCRun[A](dijc: DeltaWithIJC[A]) {
-    def runWith(a: A): A = runDeltaIO(dijc.delta.apply(a), dijc.context, dijc.id)
+    def runWith(a: A): DeltaRunResult[A] = runDeltaIO(dijc.delta.apply(a), dijc.context, dijc.id)
   }
 
   implicit class DeltaWithICRun[A](dic: DeltaWithIC[A]) {
-    def runWith(a: A): A = runDeltaIO(dic.delta.apply(a), dic.context, dic.id)
-    def runWithNewContext(a: A, context: DeltaIOContext): A = runDeltaIO(dic.delta.apply(a), context, dic.id)
+    def runWith(a: A): DeltaRunResult[A] = runDeltaIO(dic.delta.apply(a), dic.context, dic.id)
+    def runWithNewContext(a: A, context: DeltaIOContext): DeltaRunResult[A] = runDeltaIO(dic.delta.apply(a), context, dic.id)
   }
 }

--- a/shared/src/main/scala/org/rebeam/tree/sync/RefAdder.scala
+++ b/shared/src/main/scala/org/rebeam/tree/sync/RefAdder.scala
@@ -1,0 +1,30 @@
+package org.rebeam.tree.sync
+
+import org.rebeam.tree.ref.{Mirror, MirrorCodec}
+import org.rebeam.tree.sync.DeltaIORun.{AddedRef, DeltaRunResult}
+
+trait RefAdder[A] {
+  def addRefs(deltaRunResult: DeltaRunResult[A]): A
+}
+
+object RefAdder {
+  implicit val mirrorRefAdder: RefAdder[Mirror] = new RefAdder[Mirror] {
+    override def addRefs(deltaRunResult: DeltaRunResult[Mirror]): Mirror = {
+      deltaRunResult.addedRefs.foldLeft(deltaRunResult.data){
+        case (mirror, addedRef) => {
+          val ar = addedRef//.asInstanceOf[AddedRef[Any]]
+          mirror.updated(ar.id, ar.data, ar.revision)(ar.codec)
+        }
+      }
+    }
+  }
+
+  /**
+    * This can be used where the data type has no support for Refs.
+    * @tparam A The data type
+    * @return   A RefAdder that does nothing with Refs, leaving data unaltered
+    */
+  def noOpRefAdder[A]: RefAdder[A] = new RefAdder[A] {
+    override def addRefs(deltaRunResult: DeltaRunResult[A]): A = deltaRunResult.data
+  }
+}

--- a/shared/src/test/scala/org/rebeam/tree/sync/RefSpec.scala
+++ b/shared/src/test/scala/org/rebeam/tree/sync/RefSpec.scala
@@ -1,5 +1,6 @@
 package org.rebeam.tree.sync
 
+import io.circe.{Decoder, Encoder}
 import io.circe.generic.JsonCodec
 import org.rebeam.lenses.PrismN
 import org.rebeam.lenses.macros.Lenses
@@ -12,9 +13,8 @@ import org.scalatest.prop.Checkers
 
 import scala.language.higherKinds
 import org.rebeam.tree.BasicDeltaDecoders._
-import org.rebeam.tree.ref.Cache
+import org.rebeam.tree.ref.{Mirror, MirrorCodec, Ref}
 import org.rebeam.tree.ref.Ref._
-import org.rebeam.tree.ref.Ref
 
 class RefSpec extends WordSpec with Matchers with Checkers {
 
@@ -32,67 +32,76 @@ class RefSpec extends WordSpec with Matchers with Checkers {
 
     @JsonCodec
     @Lenses
-    case class Post(id: Guid[Post], message: String, userRef: Ref[User], tagRefs: List[Ref[Tag]]) extends HasId[Post] with Data
+    case class Tag(id: Guid[Tag], tag: String) extends HasId[Tag] with Data
 
     @JsonCodec
     @Lenses
-    case class Tag(id: Guid[Tag], tag: String) extends HasId[Tag] with Data
+    case class Post(id: Guid[Post], message: String, userRef: Ref[User], tagRefs: List[Ref[Tag]]) extends HasId[Post] with Data
 
-    implicit val addressPrism: PrismN[Data, Address] = PrismN.classTag("Address")
-    implicit val userPrism: PrismN[Data, User] = PrismN.classTag("User")
-    implicit val postPrism: PrismN[Data, Post] = PrismN.classTag("Post")
-    implicit val tagPrism: PrismN[Data, Tag] = PrismN.classTag("Tag")
+//    implicit val addressPrism: PrismN[Data, Address] = PrismN.classTag("Address")
+//    implicit val userPrism: PrismN[Data, User] = PrismN.classTag("User")
+//    implicit val postPrism: PrismN[Data, Post] = PrismN.classTag("Post")
+//    implicit val tagPrism: PrismN[Data, Tag] = PrismN.classTag("Tag")
   }
 
   import Data._
 
-  implicit lazy val addressDeltaDecoder: DeltaCodec[Address] =
+  implicit val addressDeltaDecoder: DeltaCodec[Address] =
     DeltaCodecs.value[Address] or lensN(Address.streetName) or lensN(Address.number)
 
-  implicit lazy val userDeltaDecoder: DeltaCodec[User] =
-    DeltaCodecs.value[User] or lensN(User.name) or lensN(User.addressRef)
-
-  implicit lazy val postDeltaDecoder: DeltaCodec[Post] =
-    DeltaCodecs.value[Post] or lensN(Post.message) or lensN(Post.userRef) or lensN(Post.tagRefs)
-
-  implicit lazy val tagDeltaDecoder: DeltaCodec[Tag] =
+  implicit val tagDeltaDecoder: DeltaCodec[Tag] =
     DeltaCodecs.value[Tag] or lensN(Tag.tag)
 
-  implicit lazy val listTagRefsDecoder: DeltaCodec[List[Ref[Tag]]] =
+  implicit val listTagRefsDecoder: DeltaCodec[List[Ref[Tag]]] =
     DeltaCodecs.optionalI[Ref[Tag]]
 
-  implicit lazy val dataDeltaCodec: DeltaCodec[Data] =
-    prismN(Data.postPrism) or prismN(Data.addressPrism) or prismN(Data.userPrism) or prismN(Data.tagPrism)
+  implicit val userDeltaDecoder: DeltaCodec[User] =
+    DeltaCodecs.value[User] or lensN(User.name) or lensN(User.addressRef)
 
+  implicit val postDeltaDecoder: DeltaCodec[Post] =
+    DeltaCodecs.value[Post] or lensN(Post.message) or lensN(Post.userRef) or lensN(Post.tagRefs)
 
-  val examplePostIO: DeltaIO[(Post, Cache[Data])] = for {
+  //  implicit lazy val dataDeltaCodec: DeltaCodec[Data] =
+//    prismN(Data.postPrism) or prismN(Data.addressPrism) or prismN(Data.userPrism) or prismN(Data.tagPrism)
+
+  // Codecs to allow use of top-level data types in mirror
+  implicit val addressMirrorCodec: MirrorCodec[Address] = MirrorCodec[Address]("address")
+  implicit val tagMirrorCodec: MirrorCodec[Tag] = MirrorCodec[Tag]("tag")
+  implicit val userMirrorCodec: MirrorCodec[User] = MirrorCodec[User]("user")
+  implicit val postMirrorCodec: MirrorCodec[Post] = MirrorCodec[Post]("post")
+
+  // Encoder and decoder for entire Mirror
+  implicit val mirrorDecoder: Decoder[Mirror] = Mirror.decoder(addressMirrorCodec, tagMirrorCodec, userMirrorCodec, postMirrorCodec)
+  implicit val mirrorEncoder: Encoder[Mirror] = Mirror.encoder
+
+  val examplePostIO: DeltaIO[(Post, Mirror)] = for {
     addressId <- getId[Address]
     userId <- getId[User]
     postId <- getId[Post]
     tagId1 <- getId[Tag]
     tagId2 <- getId[Tag]
-  } yield {
-    val post = Post(
+    m1 = Mirror.empty
+    m2 <- m1.updated(Address(addressId, "Street Name", 42))
+    m3 <- m2.updated(User(userId, "User", Ref(addressId)))
+    m4 <- m3.updated(Post(
       id = postId,
       message = "Hello World!",
       userRef = Ref(userId),
       tagRefs = List(Ref(tagId1), Ref(tagId2)))
-    val cache = Cache.empty[Data]
-      .updated(Address(addressId, "Street Name", 42))
-      .updated(User(userId, "User", Ref(addressId)))
-      .updated(post)
-      .updated(Tag(tagId1, "Tag1"))
-      .updated(Tag(tagId2, "Tag2"))
+    )
+    m5 <- m4.updated(Tag(tagId1, "Tag1"))
+    m6 <- m5.updated(Tag(tagId2, "Tag2"))
+  } yield {
     (
       //FIXME get
-      cache.getPrism(postId).get,
-      cache
+      m6.get(postId).get,
+      m6
     )
   }
 
-  val examplePost: (Post, Cache[Data]) = DeltaIORun.runDeltaIO(examplePostIO, DeltaIOContext(Moment(100)), DeltaId(ClientId(1), ClientDeltaId(1)))
+  val examplePost: (Post, Mirror) = DeltaIORun.runDeltaIO(examplePostIO, DeltaIOContext(Moment(100)), DeltaId(ClientId(1), ClientDeltaId(1)))
 
-  "Cache" should {
+  "Mirror" should {
     "produce correct refs graph" in {
       val cache = examplePost._2
       val post = examplePost._1
@@ -101,10 +110,10 @@ class RefSpec extends WordSpec with Matchers with Checkers {
       assert(cache.outgoingRefs(post.id) == Set(post.userRef.guid) ++ post.tagRefs.map(_.guid))
 
       val r = for {
-        user <- cache.prism(post.userRef)
-        address <- cache.prism(user.addressRef)
-        tag1 <- cache.prism(post.tagRefs.head)
-        tag2 <- cache.prism(post.tagRefs(1))
+        user <- cache(post.userRef)
+        address <- cache(user.addressRef)
+        tag1 <- cache(post.tagRefs.head)
+        tag2 <- cache(post.tagRefs(1))
       } yield {
         assert(cache.incomingRefs(user.id) == Set(post.id))
         assert(cache.outgoingRefs(user.id) == Set(address.id))
@@ -124,24 +133,39 @@ class RefSpec extends WordSpec with Matchers with Checkers {
     }
   }
 
-  "DeltaCodecs" should {
-    "update refs" in {
-      val post = examplePost._1
-      val postUpdated = postDeltaDecoder.updateRefsDataOnly(examplePost._1, examplePost._2)
-
-      //All refs should be updated to rev 0
-      val postExpected = Post(
-        id = post.id,
-        message = post.message,
-        userRef = RefResolved(post.userRef.guid, 0),
-        tagRefs = List(
-          RefResolved(post.tagRefs.head.guid, 0),
-          RefResolved(post.tagRefs(1).guid, 0)
-        )
-      )
-
-      assert(postUpdated == postExpected)
+  "MirrorCodec" should {
+    "encode, decode and re-encode mirror to same Json" in {
+      val encoded = mirrorEncoder(examplePost._2)
+      mirrorDecoder.decodeJson(encoded) match {
+        case Left(error) => fail(error)
+        case Right(md) =>
+          println(examplePost._2)
+          println(md)
+          assert(md === examplePost._2)
+          val reEncode = mirrorEncoder(md)
+          assert(encoded === reEncode)
+      }
     }
+  }
+
+  "DeltaCodecs" should {
+//    "update refs" in {
+//      val post = examplePost._1
+//      val postUpdated = postDeltaDecoder.updateRefsDataOnly(examplePost._1, examplePost._2)
+//
+//      //All refs should be updated to rev 0
+//      val postExpected = Post(
+//        id = post.id,
+//        message = post.message,
+//        userRef = RefResolved(post.userRef.guid, 0),
+//        tagRefs = List(
+//          RefResolved(post.tagRefs.head.guid, 0),
+//          RefResolved(post.tagRefs(1).guid, 0)
+//        )
+//      )
+//
+//      assert(postUpdated == postExpected)
+//    }
 
     "find outgoing refs" in {
       val post = examplePost._1
@@ -150,47 +174,41 @@ class RefSpec extends WordSpec with Matchers with Checkers {
       assert(rur.outgoingRefs == Set(post.userRef.guid) ++ post.tagRefs.map(_.guid))
     }
 
-    "find outgoing refs via prism" in {
-      val post = examplePost._1
-      val rur = dataDeltaCodec.updateRefs(RefUpdateResult.noRefs(post), examplePost._2)
-      assert(rur.outgoingRefs == Set(post.userRef.guid) ++ post.tagRefs.map(_.guid))
-    }
-
-    "update refs incrementally" in {
-      val post = examplePost._1
-      val cache = examplePost._2
-
-      //Update the post's refs so they have revisions
-      val postUpdated = postDeltaDecoder.updateRefsDataOnly(examplePost._1, examplePost._2)
-
-      // Get the user from the cache using updated ref having revision
-      val user = cache.prism(postUpdated.userRef).get
-
-      // Update the user data, and update the cache with thi data
-      val userUpdated = user.copy(name = "UserModified")
-      val cacheUpdated = cache.updated(userUpdated)
-
-      //Now update the post's refs again with the updated cache
-      val postUpdated2 = postDeltaDecoder.updateRefsDataOnly(postUpdated, cacheUpdated)
-
-      //User ref should be updated to rev 1, tags still at 0
-      val postExpected = Post(
-        id = post.id,
-        message = post.message,
-        userRef = RefResolved(post.userRef.guid, 1),
-        tagRefs = List(
-          RefResolved(post.tagRefs(0).guid, 0),
-          RefResolved(post.tagRefs(1).guid, 0)
-        )
-      )
-      assert(postUpdated2 == postExpected)
-
-      // And we can still get at the user in the updated cache, even with older refs
-      assert(cacheUpdated(post.userRef).contains(userUpdated))
-      assert(cacheUpdated(postUpdated.userRef).contains(userUpdated))
-      assert(cacheUpdated(postUpdated2.userRef).contains(userUpdated))
-
-    }
+//    "update refs incrementally" in {
+//      val post = examplePost._1
+//      val cache = examplePost._2
+//
+//      //Update the post's refs so they have revisions
+//      val postUpdated = postDeltaDecoder.updateRefsDataOnly(examplePost._1, examplePost._2)
+//
+//      // Get the user from the cache using updated ref having revision
+//      val user = cache.prism(postUpdated.userRef).get
+//
+//      // Update the user data, and update the cache with thi data
+//      val userUpdated = user.copy(name = "UserModified")
+//      val cacheUpdated = cache.updated(userUpdated)
+//
+//      //Now update the post's refs again with the updated cache
+//      val postUpdated2 = postDeltaDecoder.updateRefsDataOnly(postUpdated, cacheUpdated)
+//
+//      //User ref should be updated to rev 1, tags still at 0
+//      val postExpected = Post(
+//        id = post.id,
+//        message = post.message,
+//        userRef = RefResolved(post.userRef.guid, 1),
+//        tagRefs = List(
+//          RefResolved(post.tagRefs(0).guid, 0),
+//          RefResolved(post.tagRefs(1).guid, 0)
+//        )
+//      )
+//      assert(postUpdated2 == postExpected)
+//
+//      // And we can still get at the user in the updated cache, even with older refs
+//      assert(cacheUpdated(post.userRef).contains(userUpdated))
+//      assert(cacheUpdated(postUpdated.userRef).contains(userUpdated))
+//      assert(cacheUpdated(postUpdated2.userRef).contains(userUpdated))
+//
+//    }
 
   }
 


### PR DESCRIPTION
Cache[A] was unwieldy - we now have a Mirror that can contain any data type with a MirrorCodec typeclass implementation. Mirror provides data of the same type as the Ref used to look it up.

DeltaIO has been extended to support creating new data from a Guid and registering it with the Mirror (if there is one) that is at the root of the data model.